### PR TITLE
Integrate support for `throw'.

### DIFF
--- a/modules/modt-error/modt-error.c
+++ b/modules/modt-error/modt-error.c
@@ -9,8 +9,15 @@ static emacs_value Qt;
 
 static emacs_value Fmodt_error_signal (emacs_env *env, int nargs, emacs_value args[], void* data)
 {
-  assert (!env->error_check (env));
+  assert (env->error_check (env) == emacs_funcall_exit_return);
   env->error_signal (env, env->intern (env, "error"), env->make_fixnum (env, 56));
+  return Qt;
+}
+
+static emacs_value Fmodt_error_throw (emacs_env *env, int nargs, emacs_value args[], void* data)
+{
+  assert (env->error_check (env) == emacs_funcall_exit_return);
+  env->error_throw (env, env->intern (env, "tag"), env->make_fixnum (env, 65));
   return Qt;
 }
 
@@ -19,16 +26,25 @@ static emacs_value Fmodt_error_funcall (emacs_env *env, int nargs, emacs_value a
   assert (nargs == 1);
   const emacs_value result = env->funcall (env, args[0], 0, NULL);
   emacs_value error_symbol, error_data;
-  if (env->error_get (env, &error_symbol, &error_data))
+  enum emacs_funcall_exit code = env->error_get (env, &error_symbol, &error_data);
+  switch (code)
     {
-      env->error_clear (env);
-      const emacs_value Flist = env->intern (env, "list");
-      emacs_value list_args[] = {env->intern (env, "signal"), error_symbol, error_data};
-      return env->funcall (env, Flist, 3, list_args);
-    }
-  else
-    {
+    case emacs_funcall_exit_return:
       return result;
+    case emacs_funcall_exit_signal:
+      {
+        env->error_clear (env);
+        const emacs_value Flist = env->intern (env, "list");
+        emacs_value list_args[] = {env->intern (env, "signal"), error_symbol, error_data};
+        return env->funcall (env, Flist, 3, list_args);
+      }
+    case emacs_funcall_exit_throw:
+      {
+        env->error_clear (env);
+        const emacs_value Flist = env->intern (env, "list");
+        emacs_value list_args[] = {env->intern (env, "throw"), error_symbol, error_data};
+        return env->funcall (env, Flist, 3, list_args);
+      }
     }
 }
 
@@ -58,6 +74,7 @@ int emacs_module_init (struct emacs_runtime *ert)
   Qnil = env->intern (env, "nil");
   Qt = env->intern (env, "t");
   bind_function (env, "modt-error-signal", env->make_function (env, 0, 0, Fmodt_error_signal, NULL));
+  bind_function (env, "modt-error-throw", env->make_function (env, 0, 0, Fmodt_error_throw, NULL));
   bind_function (env, "modt-error-funcall", env->make_function (env, 1, 1, Fmodt_error_funcall, NULL));
   provide (env, "modt-error");
   return 0;

--- a/modules/modt-error/test.el
+++ b/modules/modt-error/test.el
@@ -8,6 +8,13 @@
 (ert-deftest modt-error-signal-test ()
   (should-error (modt-error-signal)))
 
+(ert-deftest modt-error-throw-test ()
+  (should (equal
+           (catch 'tag
+             (modt-error-throw)
+             (ert-fail "expected throw"))
+           65)))
+
 (ert-deftest modt-error-funcall-normal ()
   (should (equal (modt-error-funcall (lambda () 23))
                  23)))
@@ -18,4 +25,4 @@
 
 (ert-deftest modt-error-funcall-throw ()
   (should (equal (modt-error-funcall (lambda () (throw 'tag 32)))
-                 '(signal no-catch (tag 32)))))
+                 '(throw tag 32))))

--- a/src/emacs_module.h
+++ b/src/emacs_module.h
@@ -76,6 +76,16 @@ typedef emacs_value (*emacs_subr)(emacs_env *env,
 /* Function prototype for module user-pointer finalizers */
 typedef void (*emacs_finalizer_function)(void*) EMACS_NOEXCEPT;
 
+/* Possible Emacs function call outcomes. */
+enum emacs_funcall_exit {
+  /* Function has returned normally. */
+  emacs_funcall_exit_return = 0,
+  /* Function has signaled an error using `signal'. */
+  emacs_funcall_exit_signal = 1,
+  /* Function has exit using `throw'. */
+  emacs_funcall_exit_throw = 2,
+};
+
 struct emacs_env_25 {
   /*
    * Structure size (for version checking)
@@ -99,17 +109,21 @@ struct emacs_env_25 {
    * Error handling
    */
 
-  bool (*error_check)(emacs_env *env);
+  enum emacs_funcall_exit (*error_check)(emacs_env *env);
 
   void (*error_clear)(emacs_env *env);
 
-  bool (*error_get)(emacs_env *env,
-                    emacs_value *error_symbol_out,
-                    emacs_value *error_data_out);
+  enum emacs_funcall_exit (*error_get)(emacs_env *env,
+                                       emacs_value *error_symbol_out,
+                                       emacs_value *error_data_out);
 
   void (*error_signal)(emacs_env *env,
                        emacs_value error_symbol,
                        emacs_value error_data);
+
+  void (*error_throw)(emacs_env *env,
+                      emacs_value tag,
+                      emacs_value value);
 
   /*
    * Function registration


### PR DESCRIPTION
Slightly generalize error handling by using a tri-state enum instead of
the boolean for get_error etc.  This way we can represent a non-local
exit using `throw'.