### PR TITLE
Fix the way the main thread is determined.

### DIFF
--- a/src/emacs.c
+++ b/src/emacs.c
@@ -775,6 +775,10 @@ main (int argc, char **argv)
 
   atexit (close_output_streams);
 
+#ifdef HAVE_MODULES
+  module_init ();
+#endif
+
   sort_args (argc, argv);
   argc = 0;
   while (argv[argc]) argc++;

--- a/src/lisp.h
+++ b/src/lisp.h
@@ -3824,6 +3824,7 @@ extern bool let_shadows_global_binding_p (Lisp_Object symbol);
 extern Lisp_Object make_user_ptr (void (*finalizer) (void*), void *p);
 
 /* Defined in module.c.  */
+extern void module_init (void);
 extern void syms_of_module (void);
 #endif
 


### PR DESCRIPTION
syms_of_module is only called in an uninitialized Emacs before
dumping, so if we put the assignment of main_thread there, we will
always get the thread ID for the thread of the Emacs used for dumping,
not the current Emacs process.  Create a separate initialization
function instead that is unconditionally called from main.