### PR TITLE
Stop using AddressSanitizer in example modules.

### DIFF
--- a/modules/modt-basic/Makefile
+++ b/modules/modt-basic/Makefile
@@ -3,8 +3,8 @@ ROOT = ../..
 
 CC      = gcc
 LD      = gcc
-CFLAGS  = -ggdb3 -Wall -fsanitize=address
-LDFLAGS = -fsanitize=address
+CFLAGS  = -ggdb3 -Wall
+LDFLAGS =
 
 all: modt-basic.so modt-basic.doc
 

--- a/modules/modt-error/Makefile
+++ b/modules/modt-error/Makefile
@@ -3,8 +3,8 @@ ROOT = ../..
 
 CC      = gcc
 LD      = gcc
-CFLAGS  = -fsanitize=address -ggdb3 -Wall
-LDFLAGS = -fsanitize=address
+CFLAGS  = -ggdb3 -Wall
+LDFLAGS =
 
 all: modt-error.so modt-error.doc
 


### PR DESCRIPTION
To use AddressSanitizer the main program has to be compiled with Clang
using the -fsanitize=address flag, see
https://github.com/google/sanitizers/wiki/AddressSanitizer#using-addresssanitizer.
That this worked on OS X was probably sheer luck.